### PR TITLE
 added support for single explanatory variable

### DIFF
--- a/R/maxnet.R
+++ b/R/maxnet.R
@@ -6,12 +6,12 @@ function(p, data, f=maxnet.formula(p, data), regmult=1.0,
 {
    if (anyNA(data)) stop("NA values in data table. Please remove them and rerun.")
    if (addsamplestobackground) {
-       pdata <- data[p==1,]
-       ndata <- data[p==0,]
+       pdata <- data[p==1, , drop = FALSE]
+       ndata <- data[p==0, , drop = FALSE]
        # add to the background any presence data that isn't already in the background
        toadd <- apply(pdata, 1, function(rr) !any(apply(ndata, 1, function(r) identical(r, rr))))
        p <- c(p, rep(0, sum(toadd)))
-       data <- rbind(data, pdata[toadd,])
+       data <- rbind(data, pdata[toadd, , drop = FALSE])
    }   
    mm <- model.matrix(f, data)
    reg <- regfun(p,mm) * regmult


### PR DESCRIPTION
Hello maxnet devs,
We had an issue in `biomod2` package (https://github.com/biomodhub/biomod2/issues/102) in part related to the mismanagement of models with a single explanatory variables in `maxnet`.
I found out this was related to missing `drop = FALSE` in `maxnet` function and proposed the PR accordingly.

Below is a reproducible example that was not working with current `maxnet` version but should be solved with the PR:

```
set.seed(42)
myResp <- sample(c(0,1), size = 100, replace = TRUE)
myExpl <- data.frame(x1 = runif(100))
  
maxnet(p = myResp,
       data = myExpl)
```