### PR TITLE
add drop=TRUE to clamping to allow tibble pass-through

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,6 @@ Description: Procedures to fit species distributions models from occurrence reco
 License: MIT + file LICENSE
 URL: https://github.com/mrmaxent/maxnet
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 LazyData: true
 Encoding: UTF-8

--- a/R/predict.maxnet.R
+++ b/R/predict.maxnet.R
@@ -39,11 +39,10 @@ predict.maxnet <-
       }
       newdataframe <- as.data.frame(newdata, na.rm = FALSE)
     }
-    
-    
+
     if (clamp) {
       for (v in intersect(names(object$varmax), names(newdataframe))) {
-        newdataframe[,v] <- pmin(pmax(newdataframe[,v], object$varmin[v]), object$varmax[v])
+        newdataframe[,v] <- pmin(pmax(newdataframe[,v, drop = TRUE], object$varmin[v]), object$varmax[v])
       }
     }
     terms <- sub("hinge\\((.*)\\):(.*):(.*)$", "hingeval(\\1,\\2,\\3)", names(object$betas))

--- a/R/predict.maxnet.R
+++ b/R/predict.maxnet.R
@@ -31,13 +31,13 @@ predict.maxnet <-
       if (!requireNamespace("stars", quietly = TRUE)) {
         stop("package stars required, please install it first")
       }
-      newdataframe <- as.data.frame(newdata)[, -c(1,2)]
+      newdataframe <- as.data.frame(newdata)[, -c(1,2), drop = FALSE]
     }
     if (is_spatraster <- inherits(newdata, "SpatRaster")) {
       if (!requireNamespace("terra", quietly = TRUE)) {
         stop("package terra required, please install it first")
       }
-      newdataframe <- as.data.frame(newdata, na.rm = FALSE)
+      newdataframe <- as.data.frame(newdata, na.rm = FALSE, drop = FALSE)
     }
 
     if (clamp) {


### PR DESCRIPTION
Hi,

A tiny modification proposal...  this pull request makes it possible to provide the `newdata` argument to `predict()` as a tibble in addition to as a data.frame or matrix.  Single square bracket indexing (ala `x[,column_name]`) into a tibble [always returns another tibble](https://tibble.tidyverse.org/reference/subsetting.html) unless  `drop = TRUE` is included in the argument list.   

https://github.com/BigelowLab/maxnet/blob/afa40f410f0fc65bb62e6f4b1c0cc4232ef79269/R/predict.maxnet.R#L45

Best wishes,
Ben
